### PR TITLE
Simplify ActionResp to have consistent Generic Aeson encoding

### DIFF
--- a/src/ClientActions.hs
+++ b/src/ClientActions.hs
@@ -72,9 +72,9 @@ instance ToJSON ActionReq where
 actionRespOptions :: Options
 actionRespOptions = defaultOptions { fieldLabelModifier = map toLower . drop 6 } 
 
-data ActionResp = MoveResp      { mvRespId :: TransportId, mvRespPoint ::  Point }
-                | RotateResp    { roRespId :: TransportId, roRespAngle :: Angle }
-                | GameWorldResp { gwRespGameWorld :: GameWorld }
+data ActionResp = MoveResp TransportId Point
+                | RotateResp TransportId Angle
+                | GameWorldResp GameWorld
                deriving (Generic)
                
 instance FromJSON ActionResp where


### PR DESCRIPTION
Aeson inconsistently encodes sum data types with record arguments

Given
```haskell
data Whatever = X { tag :: String} | Y { y :: String} deriving (Generic)

instance ToJSON Whatever where                                                                                                                                                               
  toJSON = genericToJSON defaultOptions

main = do
  print (encode (X {tag="hello"}))                                                                                                                                                           
  print (encode (Y {y="hello"})) 
```
Produces
```
"{\"tag\":\"hello\"}"
"{\"tag\":\"Y\",\"y\":\"hello\"}"
```
